### PR TITLE
Fix attribute name for active class in init_page.js

### DIFF
--- a/askbot/media/js/pages/question/init_page.js
+++ b/askbot/media/js/pages/question/init_page.js
@@ -21,7 +21,7 @@ function initEditor(){
 PostVote.init();
 
 $(document).ready(function(){
-  $("#js-answers-sort-" + askbot['data']['answersSortTab']).attr('className',"js-active");
+  $("#js-answers-sort-" + askbot['data']['answersSortTab']).attr('class',"js-active");
 
   if (askbot['data']['threadIsClosed'] === false) {
     initEditor();


### PR DESCRIPTION
When assigning styles to the sort nav, the active nav element could be selected with something like `.components--sort-nav a[className="js-selected"]`. However, it seems the intention is to use the `class` attribute so that the selection could be performed with `.components--sort-nav a.js-selected`.

Additional notes:
- I did not investigate any downstream effects.
- The attribute `className` is similarly assigned in `jinja2/user_profile/user_edit.html` which may be worth reviewing.
